### PR TITLE
fix error about: Could not find NET with id 0” / “id 7”

### DIFF
--- a/src/graph/topo.cc
+++ b/src/graph/topo.cc
@@ -1521,8 +1521,9 @@ ncclResult_t ncclTopoSmartGetNet(struct ncclTopoSystem* system, int rank, int ch
     // suppose the 2 gpus are neighbor to each other
     for(int n = 0; n < localNetCount; n++) {
       if(gpu % localNetCount == n) {
-        *id = localNets[n];
-        *backupId = localNets[(n + 1) % localNetCount];
+        *id = system->nodes[NET].nodes[localNets[n]].id;
+        *backupId = system->nodes[NET].nodes[localNets[(n + 1) % localNetCount]].id;
+        break;
       }
     }
   }


### PR DESCRIPTION
This pr fix the bug of : two gpu have two nic case. Now, gpu0 will use nic0 as primary nic, nic1 as backup nic. And, gpu1 will use nic1 as primary nic, nic0 as backup nic.
```cpp
if (gpu % localNetCount == n) {
        *id = system->nodes[NET].nodes[localNets[n]].id;
        *backupId = system->nodes[NET].nodes[localNets[(n + 1) % localNetCount]].id;
        break;
}
```