### PR TITLE
add two env to fix 4nodes data error

### DIFF
--- a/nccl4py/examples/01_basic/03_alltoallv.py
+++ b/nccl4py/examples/01_basic/03_alltoallv.py
@@ -16,6 +16,8 @@ mpirun -np 32 \
   -x NCCL_NET_PLUGIN= \
   -x NCCL_NVLS_ENABLE=0 \
   python examples/01_basic/03_alltoallv.py\
+  # -x NCCL_RMA_RELAY_CHUNKS=3 \
+  # -x NCCL_RMA_COLL_BARRIER=1 \
 """
 
 import sys

--- a/nccl4py/examples/01_basic/03_alltoallv.py
+++ b/nccl4py/examples/01_basic/03_alltoallv.py
@@ -17,7 +17,6 @@ mpirun -np 32 \
   -x NCCL_NVLS_ENABLE=0 \
   python examples/01_basic/03_alltoallv.py\
   # -x NCCL_RMA_RELAY_CHUNKS=3 \
-  # -x NCCL_RMA_COLL_BARRIER=1 \
 """
 
 import sys

--- a/src/collectives.cc
+++ b/src/collectives.cc
@@ -113,7 +113,7 @@ NCCL_API(ncclResult_t, ncclAlltoAllv, const void* sendbuff, const size_t* sendco
     void* relaybuff, size_t relaycount, ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream);
 ncclResult_t ncclAlltoAllv(const void* sendbuff, const size_t* sendcounts,
     const size_t* sdispls, void* recvbuff, const size_t* recvcounts, const size_t* rdispls,
-    void* relaybuff, size_t relaycount, ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream) {
+    void* relaybuff, size_t relaycounts, ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream) {
   // Calculate total send bytes for current rank: sum of all sendcounts for this rank
   size_t totalBytes = 0;
   if (comm && sendcounts) {
@@ -128,7 +128,7 @@ ncclResult_t ncclAlltoAllv(const void* sendbuff, const size_t* sendcounts,
   struct ncclInfo info = { ncclFuncAlltoAllV, "AlltoAllv",
     sendbuff, recvbuff, 0, datatype, ncclSum, 0, comm, stream, /* Args */
     0, 0, 0, nullptr, 0, 0, 0, 0, nullptr,
-    sendcounts, sdispls, recvcounts, rdispls, relaybuff, relaycount };
+    sendcounts, sdispls, recvcounts, rdispls, relaybuff, relaycounts};
   return ncclEnqueueCheck(&info);
 }
 

--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -2970,6 +2970,7 @@ ncclResult_t rmaCollTaskAppend(
   t->recvWinOffset = recvWinOffset;
   t->relayWin = comm->nNodes > 1 ? relayWin : nullptr;
   t->relayWinOffset = comm->nNodes > 1 ? relayWinOffset : 0;
+  t->relaycounts = info->relaycounts;
   t->sendcounts = info->sendcounts;
   t->sdispls = info->sdispls;
   t->recvcounts = info->recvcounts;

--- a/src/include/comm.h
+++ b/src/include/comm.h
@@ -309,6 +309,7 @@ struct ncclTaskRmaColl {
   // Window info for relay buffer (optional, for multi-node)
   struct ncclDevrWindow* relayWin;
   size_t relayWinOffset;
+  size_t relaycounts;
 
   // Counts and displacements
   const size_t* sendcounts;

--- a/src/include/info.h
+++ b/src/include/info.h
@@ -43,7 +43,7 @@ struct ncclInfo {
   const size_t* recvcounts;
   const size_t* rdispls;
   void* relaybuff;
-  size_t relaycount;
+  size_t relaycounts;
 };
 
 #endif

--- a/src/rma/rma_coll.cc
+++ b/src/rma/rma_coll.cc
@@ -444,7 +444,7 @@ ncclResult_t scheduleRmaCollTasksToPlan(struct ncclComm* comm, struct ncclKernel
         // (ceRecvRankSameRail ---> sched.rank ---relay--> other_local_ranks)
         // Data received at sameRail rank needs to be distributed locally
         int ceRecvRankSameRail = comm->nodeRanks[ceRecvNode].localRankToRank[sched.localRank];
-        size_t relayToggleOffset = (batchIdx-1) % sched->relayChunks * sched.relayChunkBytes;
+        size_t relayToggleOffset = (batchIdx-1) % sched.relayChunks * sched.relayChunkBytes;
         size_t innerOffset = 0; // accumulated offset in relay buffer between multiple ranks on the same node
         for (int lr = 0; lr < sched.localRanks; lr++) {
           int destRank = comm->localRankToRank[lr];
@@ -567,7 +567,7 @@ ncclResult_t scheduleRmaCollTasksToPlan(struct ncclComm* comm, struct ncclKernel
         {
           int sendNode = (sched.node + proxyNodeDelta) % sched.nNodes;
           int sendRankSameRail = comm->nodeRanks[sendNode].localRankToRank[sched.localRank];
-          size_t relayToggleOffset = batchIdx % sched->relayChunks * sched.relayChunkBytes;
+          size_t relayToggleOffset = batchIdx % sched.relayChunks * sched.relayChunkBytes;
           size_t innerOffset = 0; // accumulated offset in relay buffer between multiple ranks on the same node
           for (int lr = 0; lr < comm->nodeRanks[sendNode].localRanks; lr++) {
             int targetRank = comm->nodeRanks[sendNode].localRankToRank[lr];

--- a/src/rma/rma_coll.cc
+++ b/src/rma/rma_coll.cc
@@ -198,9 +198,6 @@ ncclResult_t ncclLaunchRmaColl(struct ncclComm* comm, struct ncclKernelPlan* pla
     NCCLCHECK(ncclRmaCollInit(comm));
   }
 
-  const char* relayEnv = ncclGetEnv("NCCL_RMA_RELAY_CHUNKS");
-  bool relayChunksCustom = relayEnv && relayEnv[0] != '\0';
-
   int batchIdx = 0;
   // Iterate through each RMA work batch
   struct ncclRmaWorkBatch* batch = ncclIntruQueueHead(&plan->rmaWorkBatchQueue);


### PR DESCRIPTION
Add two env to fix 4nodes data error, only one of them can be in effect at the same time. 
* `NCCL_RMA_RELAY_CHUNKS` to control the number of  relay chunks, which is equal to nNodes - 1
* `NCCL_RMA_COLL_BARRIER` to add a barrier after one batch launch

This pr just a short-term plan case using barriers/increasing the length of the relay not perfect. We will add a notification ProxyPut/Wait( in another ctx) after the relay data is consumed during the execution phase to ensure converage and address potential issues.